### PR TITLE
postprocess: remove use of double-quoted strings

### DIFF
--- a/postprocess.sql
+++ b/postprocess.sql
@@ -18,7 +18,7 @@ CREATE TABLE bare_inflections (`word_id` INTEGER NOT NULL, `bare` VARCHAR(100) N
 -- also be BINARY collated. See also:
 -- https://www.sqlite.org/optoverview.html#the_like_optimization
 CREATE INDEX idx_bare_inflections_bare ON bare_inflections (`bare`);
-INSERT INTO bare_inflections SELECT word_id, REPLACE(temp, "'", "") AS bare
+INSERT INTO bare_inflections SELECT word_id, REPLACE(temp, '''', '') AS bare
 FROM (
 	-- Search word might be a noun or adjective declension
 	SELECT word_id, nom AS temp FROM declensions
@@ -72,7 +72,7 @@ FROM (
 	UNION ALL
 	SELECT word_id, pl3 AS temp FROM conjugations
 )
-WHERE bare <> "";
+WHERE bare <> '';
 
 -- Saves a few megabytes
 VACUUM;


### PR DESCRIPTION
As of SQLite 3.41.0, their use is disabled by default.

```
unzip -p openrussian-sql.zip openrussian.sql | awk -f ./mysql2sqlite - | sqlite3 openrussian-sqlite3.db
awk: ./mysql2sqlite:214: warning: regexp escape sequence `\"' is not a known regexp operator
memory
sqlite3 openrussian-sqlite3.db -batch <postprocess.sql
Parse error near line 21: no such column: '
  TO bare_inflections SELECT word_id, REPLACE(temp, "'", "") AS bare FROM (  --
                                      error here ---^
make: *** [Makefile:29: openrussian-sqlite3.db] Error 1
```